### PR TITLE
Removed clientUri()

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ function Emitter(redis, opts){
   opts = opts || {};
 
   if ('string' == typeof redis) {
-    redis = clientUri(redis);
+    redis = client(redis);
   }
 
   if (redis && !redis.hset) {
@@ -155,17 +155,3 @@ Emitter.prototype.emit = function(){
 
   return this;
 };
-
-/**
- * Create a redis client from a
- * `host:port` uri string.
- *
- * @param {String} uri
- * @return {Client} node client
- * @api private
- */
-
-function clientUri(uri){
-  uri = uri.split(':');
-  return client(uri[1], uri[0]);
-}


### PR DESCRIPTION
Fall back to the native support of the Redis protocol URL, so we can connect to Redis using authentication. This allows us even to pass the Heroku env variable process.env.REDIS_URL and have it all working.

- Issue #40