### PR TITLE
Bump dependencies and move to msgpack-lite

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@
 var client = require('redis').createClient;
 var parser = require('socket.io-parser');
 var hasBin = require('has-binary');
-var msgpack = require('msgpack-js');
+var msgpack = require('msgpack-lite');
 var debug = require('debug')('socket.io-emitter');
 
 /**

--- a/package.json
+++ b/package.json
@@ -10,17 +10,17 @@
     "test": "make test"
   },
   "dependencies": {
-    "debug": "2.2.0",
-    "redis": "2.4.2",
-    "msgpack-js": "0.3.0",
+    "debug": "2.3.3",
+    "redis": "2.6.3",
+    "msgpack-lite": "0.1.26",
     "has-binary": "0.1.7",
-    "socket.io-parser": "2.2.6"
+    "socket.io-parser": "2.3.2"
   },
   "devDependencies": {
-    "mocha": "2.3.4",
-    "expect.js": "0.3.1",
-    "socket.io": "1.3.7",
-    "socket.io-client": "1.3.7",
-    "socket.io-redis": "0.2.0"
+    "mocha": "~3.2.0",
+    "expect.js": "~0.3.1",
+    "socket.io": "~1.7.2",
+    "socket.io-client": "~1.7.2",
+    "socket.io-redis": "~3.0.0"
   }
 }


### PR DESCRIPTION
- bump debug to version 2.3.3
- bump redis to version 2.6.3
- bump socket.io-parser to version 2.3.2
- bump mocha to version 3.2.0
- bump expect.js to version 0.3.1
- bump socket.io to version 1.7.2
- bump socket.io-client to version 1.7.2
- bump socket.io-redis to version 3.0.0