### PR TITLE
bump debug to ~2.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "make test"
   },
   "dependencies": {
-    "debug": "^2.6.4",
+    "debug": "~2.6.4",
     "notepack.io": "~1.0.1",
     "redis": "2.6.3",
     "socket.io-parser": "2.3.2"

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "test": "make test"
   },
   "dependencies": {
-    "debug": "2.3.3",
-    "redis": "2.6.3",
+    "debug": "^2.6.4",
     "notepack.io": "~1.0.1",
+    "redis": "2.6.3",
     "socket.io-parser": "2.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Along with https://github.com/socketio/socket.io-adapter/pull/52, this brings all the socket.io packages up to the same version of debug, one that doesn't get flagged as having vulnerabilities because of its version of `ms`.