### PR TITLE
updated debug to fix ms vuln 

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "make test"
   },
   "dependencies": {
-    "debug": "~2.6.4",
+    "debug": "~2.6.8",
     "notepack.io": "~2.1.0",
     "redis": "2.6.3",
     "socket.io-parser": "2.3.2"

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
     "test": "make test"
   },
   "dependencies": {
-    "debug": "~2.6.8",
+    "debug": "~3.1.0",
     "notepack.io": "~2.1.0",
     "redis": "2.6.3",
-    "socket.io-parser": "2.3.2"
+    "socket.io-parser": "3.1.2"
   },
   "devDependencies": {
     "mocha": "~3.2.0",


### PR DESCRIPTION
debug@2.6.4 depended on a version of ms which reported by snyk to be vulnerable albeit false positive, but this still break ci and build process as reported in https://github.com/visionmedia/debug/issues/469.