### PR TITLE
Fixed binary events being mark as regular events

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@
 var client = require('redis').createClient;
 var parser = require('socket.io-parser');
 var msgpack = require('notepack.io');
+var hasBin = require('has-binary2');
 var debug = require('debug')('socket.io-emitter');
 
 /**
@@ -123,7 +124,7 @@ Emitter.prototype.of = function(nsp){
 Emitter.prototype.emit = function(){
   // packet
   var args = Array.prototype.slice.call(arguments);
-  var packet = { type: parser.EVENT, data: args, nsp: this.nsp };
+  var packet = { type: hasBin(args) ? parser.BINARY_EVENT : parser.EVENT, data: args, nsp: this.nsp };
 
   var opts = {
     rooms: this._rooms,

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "debug": "~3.1.0",
+    "has-binary2": "~1.0.2",
     "notepack.io": "~2.1.0",
     "redis": "2.6.3",
     "socket.io-parser": "3.1.2"


### PR DESCRIPTION
Socket.io-emitter is marking all emitted events as regular events, included check for marking them as binary events if needed.