### PR TITLE
[chore] Bump debug to version 4.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - "4"
   - "6"
   - "8"
 services:

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "make test"
   },
   "dependencies": {
-    "debug": "~3.1.0",
+    "debug": "~4.1.0",
     "notepack.io": "~2.1.0",
     "redis": "2.6.3",
     "socket.io-parser": "3.1.2"


### PR DESCRIPTION
Syncing the version of debug throughout the repositories.
https://github.com/socketio/engine.io/pull/581
https://github.com/socketio/socket.io-client/pull/1304
https://github.com/socketio/socket.io-parser/pull/92
https://github.com/socketio/engine.io-client/pull/612
https://github.com/socketio/socket.io-redis/pull/306