### PR TITLE
Made changes to add a `remoteDisconnect` feature

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,7 +163,6 @@ Emitter.prototype.emit = function(){
 
 Emitter.prototype.remoteDisconnect = function(id) {
   const requestId = uid2(6);
-  var args = Array.prototype.slice.call(arguments);
 
   const request = JSON.stringify({
     requestId: requestId,

--- a/package-lock.json
+++ b/package-lock.json
@@ -746,8 +746,7 @@
     "uid2": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I=",
-      "dev": true
+      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "debug": "~4.1.0",
     "notepack.io": "~2.1.0",
     "redis": "2.6.3",
-    "socket.io-parser": "3.1.2"
+    "socket.io-parser": "3.1.2",
+    "uid2": "0.0.3"
   },
   "devDependencies": {
     "expect.js": "~0.3.1",


### PR DESCRIPTION
Added remoteDisconnect feature. Needed it for a personal project i'm in the middle of doing right now. Where a API needs to disconnect a user depending on their action where the socket.io is in pod on kubernetes, using socket.io-redis to keep them in sync, and idk what socket.io server has the user, so i need a remoteDisconnect feature since i do store their socketid.