### PR TITLE
Apply async redis features

### DIFF
--- a/lib/typed-events.ts
+++ b/lib/typed-events.ts
@@ -33,5 +33,5 @@ export interface TypedEventBroadcaster<EmitEvents extends EventsMap> {
   emit<Ev extends EventNames<EmitEvents>>(
     ev: Ev,
     ...args: EventParams<EmitEvents, Ev>
-  ): boolean;
+  ): Promise<boolean>;
 }


### PR DESCRIPTION
[node-redis](https://github.com/redis/node-redis) presented new major version 4.x.x. One of the most highlighted changes is ***Promise*** support. At the current moment **redis-emitter** works fine with **node-redis v4** :rocket:. But there can be some obstacles. For instance, if you work with ***AWS Lambda*** you have to <ins>connect to redis</ins>, <ins>do some stuff</ins>, <ins>disconnect from redis</ins>. If ```this.redisClient.publish()``` call isn't completed yet then you will receive an error.
```js
const client = await redis.connect();
const emitter = new Emitter(client);

emitter.emit('event', data);

await client.disconnect();

// Lambda run fails
```
This pr fixes it. @darrachequesne please take a look at the commit. Probably it should be merged