### PR TITLE
Add option to allow usage of custom parser

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -161,6 +161,7 @@ option set to `true`.
 The following options are allowed:
 
 - `key`: the name of the key to pub/sub events on as prefix (`socket.io`)
+- `parser`: parser to use for encoding messages to Redis ([`notepack.io](https://www.npmjs.com/package/notepack.io))
 
 ### Emitter#to(room:String):BroadcastOperator
 ### Emitter#in(room:String):BroadcastOperator


### PR DESCRIPTION
Sibling PR to https://github.com/socketio/socket.io-redis-adapter/pull/471. This adds the same `parser` option here so that can plug in an alternative parser to encode messages to redis. See the other PR and its associated issue for more context.

One thing of note is that this is technically not BC due to modifying the `broadcastOptions` to require `parser` and that `BroadcastOperator` is exported, so if someone was importing it themselves for some reason, then they'd need to update their usage. However, I'm not sure how common a use case that is or how many people would be affected for this to warrant much concern. An alternative BC approach would be to make `parser` optional to `broadcastOptions` and then set it to the default within the constructor, but I rejected that approach initially just to keep the code as similar as it currently is.